### PR TITLE
Vscode extension single download

### DIFF
--- a/chroot-overlay/usr/share/liox-config/install_vscode_ext.sh
+++ b/chroot-overlay/usr/share/liox-config/install_vscode_ext.sh
@@ -1,28 +1,46 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 if [ "$(id -u)" -ne 0 ]; then
-	echo "Please run as root"
-	exit
+    echo "Please run as root"
+    exit 1
 fi
 
-if [ "$#" -ne 1 ]; then
-	echo "Usage: $0 <user>"
-	exit
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <user_list>"
+    exit 1
 fi
 
-if [ ! -d "/home/$1" ]; then
-	echo "User $1 does not exist"
-else
-	VSCODE_DIR=/home/$1/.vscode/extensions
-	su - $1 -c "mkdir -p $VSCODE_DIR"
-	if [ ! -f "$VSCODE_DIR/extensions.json" ]; then
-		echo "Creating extensions.json"
-		echo "[]" > "$VSCODE_DIR/extensions.json"
-		chown $1:$1 "$VSCODE_DIR/extensions.json"
-	fi
-	su - $1 -c "code --extensions-dir $VSCODE_DIR --install-extension ms-vscode.cpptools-extension-pack"
-	echo "Removing VSIXs"
-	rm -f /home/$1/.config/Code/CachedExtensionVSIXs/*
+FIRST_USER="$1"
+shift
+OTHER_USERS=("$@")
+EXTENSION_NAME="ms-vscode.cpptools-extension-pack"
+
+echo "Will install vscode extension: '$EXTENSION_NAME'"
+echo "Will install from internet for user: ${FIRST_USER}"
+if [ "${#OTHER_USERS[@]}" -ne 0 ]; then
+    echo "Will install from cached VSIXs for users: ${OTHER_USERS[@]}"
 fi
+
+cleanup_tmpdir() {
+    echo "Removing ${VSIX_TMP_DIR}"
+    rm -rf "${VSIX_TMP_DIR}"
+}
+
+VSIX_TMP_DIR="$(mktemp -d /tmp/vscode-vsix.XXXXXXXXX)"
+trap cleanup_tmpdir EXIT
+
+echo "Installing from internet for ${FIRST_USER}"
+sudo -u "${FIRST_USER}" code --install-extension ${EXTENSION_NAME}
+install_args=()
+for f in "/home/${FIRST_USER}/.config/Code/CachedExtensionVSIXs/"*; do
+    vsix_file="${VSIX_TMP_DIR}/$(basename "${f}").vsix"
+    mv "${f}" "${vsix_file}"
+    install_args+=(--install-extension "${vsix_file}")
+done
+chmod 777 "${VSIX_TMP_DIR}"
+for user in "${OTHER_USERS[@]}"; do
+    echo "Installing from VSIXs for ${user}"
+    sudo -u "${user}" code ${install_args[@]}
+done

--- a/chroot-script.sh
+++ b/chroot-script.sh
@@ -108,13 +108,13 @@ function make_user()
 make_user lioadmin "${LIOADMIN_PWD}"
 usermod -a -G sudo lioadmin
 
-if [ -n "${D0_PWD}" ]; then
+if [[ -v D0_PWD ]]; then
     make_user d0 "${D0_PWD}"
 fi
-if [ -n "${D1_PWD}" ]; then
+if [[ -v D1_PWD ]]; then
     make_user d1 "${D1_PWD}"
 fi
-if [ -n "${D2_PWD}" ]; then
+if [[ -v D2_PWD ]]; then
     make_user d2 "${D2_PWD}"
 fi
 

--- a/chroot-script.sh
+++ b/chroot-script.sh
@@ -96,13 +96,13 @@ echo -n "${CTRL_KEY}" > /etc/olimp-control/key
 chown root:root /etc/olimp-control/key
 chmod 400 /etc/olimp-control/key
 
+USER_LIST=()
 function make_user()
 {
     local USERNAME="$1"
     local PASSWORD_HASH=$(echo "$2" | mkpasswd -s -m sha-512)
+    USER_LIST+=("${USERNAME}")
     useradd -m -s /bin/bash -p "${PASSWORD_HASH}" "${USERNAME}"
-    /usr/share/liox-config/install_vscode_ext.sh "${USERNAME}"
-    sleep 10
 }
 
 make_user lioadmin "${LIOADMIN_PWD}"
@@ -117,6 +117,7 @@ fi
 if [[ -v D2_PWD ]]; then
     make_user d2 "${D2_PWD}"
 fi
+/usr/share/liox-config/install_vscode_ext.sh "${USER_LIST[@]}"
 
 GRUB_PWD_HASH=$(printf "%s\n%s" "${GRUB_PWD}" "${GRUB_PWD}" | grub-mkpasswd-pbkdf2 | awk '/grub.pbkdf/{print$NF}')
 mkdir -p /boot/grub


### PR DESCRIPTION
install_vscode_ext.sh now supports installation for multiple users, downloading the VSIXs once.

It would be possible to download the VSIX files directly and install them (see https://stackoverflow.com/questions/37071388/how-can-i-install-visual-studio-code-extensions-offline), but that would mean we'd have to download each extension from the C++ pack seperately (as the pack only contains metadata - i.e. which extensions are included in the pack).